### PR TITLE
Feature/callbacks optional keys

### DIFF
--- a/inferno/callbacks.py
+++ b/inferno/callbacks.py
@@ -203,6 +203,14 @@ class BestLoss(Callback):
       better. E.g., log loss should get -1, whereas accuracy should
       get 1.
 
+    keys_optional: list of str or None (default=None)
+      If not None, this should be a list of keys whose presence is
+      optional. By default, keys indicated in `key_signs` are
+      mandatory, but sometimes we want optional keys. E.g., if keys
+      refer to validation data, but validation data is not always
+      present, those keys should be optional. When a key that is not
+      optional is missing, an exception will be raised.
+
     Attributes
     ----------
     default_key_signs

--- a/inferno/callbacks.py
+++ b/inferno/callbacks.py
@@ -14,15 +14,10 @@ from tabulate import tabulate
 
 from inferno.utils import Ansi
 from inferno.utils import check_history_slice
+from inferno.utils import duplicate_items
 from inferno.utils import flatten
 from inferno.utils import to_numpy
 from inferno.utils import to_var
-
-
-def _duplicate_items(collection_0, collection_1):
-    set_0 = set(collection_0)
-    set_1 = set(collection_1)
-    return set_0 & set_1
 
 
 class Callback:
@@ -165,7 +160,7 @@ class AverageLoss(Callback):
             yield key_loss, list(zip(*row))
 
     def _check_keys_duplicated(self):
-        duplicates = _duplicate_items(self.default_key_sizes, self.key_sizes)
+        duplicates = duplicate_items(self.default_key_sizes, self.key_sizes)
         if duplicates:
             raise ValueError("AverageLoss found duplicate keys: {}"
                              "".format(', '.join(sorted(duplicates))))
@@ -240,7 +235,7 @@ class BestLoss(Callback):
         return (key in self.keys_optional) or (key in self.default_key_signs)
 
     def _check_keys_duplicated(self):
-        duplicates = _duplicate_items(self.default_key_signs, self.key_signs)
+        duplicates = duplicate_items(self.default_key_signs, self.key_signs)
         if duplicates:
             raise ValueError("BestLoss found duplicate keys: {}"
                              "".format(', '.join(sorted(duplicates))))
@@ -444,7 +439,7 @@ class PrintLog(Callback):
         return (key in self.keys_optional) or (key in self.default_keys)
 
     def _check_keys_duplicated(self):
-        duplicates = _duplicate_items(self.default_keys, self.keys)
+        duplicates = duplicate_items(self.default_keys, self.keys)
         if duplicates:
             raise ValueError("PrintLog found duplicate keys: {}"
                              "".format(', '.join(sorted(duplicates))))

--- a/inferno/callbacks.py
+++ b/inferno/callbacks.py
@@ -166,6 +166,7 @@ class AverageLoss(Callback):
 
     def _check_keys_missing(self, history):
         check_keys = []
+        # check loss keys and size keys alike
         for key in flatten(self.key_sizes.items()):
             if not self._is_optional(key):
                 check_keys.append(key)
@@ -373,11 +374,11 @@ class PrintLog(Callback):
 
     keys_optional: list of str or None (default=None)
       If not None, this should be a list of keys whose presence is
-      optional. By default, keys indicated in `key` are mandatory, but
-      sometimes we want optional keys. E.g., if keys refer to
-      validation data, but validation data is not always present,
-      those keys should be optional. When a key that is not optional
-      is missing, an exception will be raised.
+      optional. By default, keys indicated in `key` must be in the
+      history, but sometimes we want optional keys. E.g., if keys
+      refer to validation data, but validation data is not always
+      present, those keys should be optional. When a key that is not
+      optional is missing, an exception will be raised.
 
     sink : callable (default=print)
       The target that the output string is sent to. By default, the

--- a/inferno/callbacks.py
+++ b/inferno/callbacks.py
@@ -126,7 +126,7 @@ class AverageLoss(Callback):
       determined. If any of the losses is not present, it is
       ignored.
 
-      """
+    """
     default_key_sizes = {'train_loss': 'train_batch_size',
                          'valid_loss': 'valid_batch_size'}
 

--- a/inferno/net.py
+++ b/inferno/net.py
@@ -750,14 +750,23 @@ class NeuralNetClassifier(NeuralNet):
 
     default_callbacks = [
         ('epoch_timer', EpochTimer()),
-        ('average_loss', AverageLoss({'valid_acc': 'valid_batch_size'})),
+        ('average_loss', AverageLoss(
+            key_sizes={'valid_acc': 'valid_batch_size'},
+            keys_optional=['valid_acc'],
+        )),
         ('accuracy', Scoring(
             name='valid_acc',
             scoring='accuracy_score',
             pred_extractor=accuracy_pred_extractor,
         )),
-        ('best_loss', BestLoss(key_signs={'valid_acc': 1})),
-        ('print_log', PrintLog(keys=['valid_acc', 'valid_acc_best'])),
+        ('best_loss', BestLoss(
+            key_signs={'valid_acc': 1},
+            keys_optional=['valid_acc'],
+        )),
+        ('print_log', PrintLog(
+            keys=['valid_acc', 'valid_acc_best'],
+            keys_optional=['valid_acc', 'valid_acc_best'],
+        )),
     ]
 
     def __init__(

--- a/inferno/tests/conftest.py
+++ b/inferno/tests/conftest.py
@@ -41,6 +41,8 @@ def get_history(*callbacks, history_cls=history_cls, with_valid=True):
             for cb in callbacks:
                 cb.on_batch_end(net)
 
+            h.record_batch('text', 'ha')
+
         h.record('epoch', epoch)
         h.record('text', text)
         for cb in callbacks:

--- a/inferno/tests/test_callbacks.py
+++ b/inferno/tests/test_callbacks.py
@@ -212,14 +212,45 @@ class TestBestLoss:
             get_history(avg_loss, best_loss)
 
         expected = ("Key 'missing' could not be found in history; "
-                    "maybe there was a typo?")
+                    "maybe there was a typo? To make this key optional, "
+                    "add it to the 'keys_optional' parameter.")
         assert exc.value.args[0] == expected
+
+    def test_missing_key_optional(self, best_loss_cls, avg_loss):
+        best_loss = best_loss_cls(
+            key_signs={'missing': 1}, keys_optional=['missing']).initialize()
+
+        # does not raise
+        get_history(avg_loss, best_loss)
+
+    def test_missing_key_optional_as_str(self, best_loss_cls, avg_loss):
+        best_loss = best_loss_cls(
+            key_signs={'missing': 1}, keys_optional='missing').initialize()
+
+        # does not raise
+        get_history(avg_loss, best_loss)
 
     def test_sign_not_allowed(self, best_loss_cls):
         with pytest.raises(ValueError) as exc:
             best_loss_cls(key_signs={'epoch': 2}).initialize()
 
         expected = "Wrong sign 2, expected one of -1, 1."
+        assert exc.value.args[0] == expected
+
+    def test_1_duplicate_key(self, best_loss_cls):
+        key_signs = {'train_loss': 1}
+        with pytest.raises(ValueError) as exc:
+            best_loss_cls(key_signs=key_signs).initialize()
+
+        expected = "BestLoss found duplicate keys: train_loss"
+        assert exc.value.args[0] == expected
+
+    def test_2_duplicate_keys(self, best_loss_cls):
+        key_signs = {'train_loss': 1, 'valid_loss': 1}
+        with pytest.raises(ValueError) as exc:
+            best_loss_cls(key_signs=key_signs).initialize()
+
+        expected = "BestLoss found duplicate keys: train_loss, valid_loss"
         assert exc.value.args[0] == expected
 
 

--- a/inferno/tests/test_utils.py
+++ b/inferno/tests/test_utils.py
@@ -1,0 +1,35 @@
+import pytest
+
+
+class TestDuplicateItems:
+    @pytest.fixture
+    def duplicate_items(self):
+        from inferno.utils import duplicate_items
+        return duplicate_items
+
+    @pytest.mark.parametrize('collections', [
+        ([],),
+        ([], []),
+        ([], [], []),
+        ([1, 2]),
+        ([1, 2], [3]),
+        ([1, 2], [3, '1']),
+        ([1], [2], [3], [4]),
+        ({'1': 1}, [2]),
+        ({'1': 1}, {'2': 1}, ('3', '4')),
+    ])
+    def test_no_duplicates(self, duplicate_items, collections):
+        assert duplicate_items(*collections) == set()
+
+    @pytest.mark.parametrize('collections, expected', [
+        ([1, 1], {1}),
+        (['1', '1'], {'1'}),
+        ([[1], [1]], {1}),
+        ([[1, 2, 1], [1]], {1}),
+        ([[1, 1], [2, 2]], {1, 2}),
+        ([[1], {1: '2', 2: '2'}], {1}),
+        ([[1, 2], [3, 4], [2], [3]], {2, 3}),
+        ([{'1': 1}, {'1': 1}, ('3', '4')], {'1'}),
+    ])
+    def test_duplicates(self, duplicate_items, collections, expected):
+        assert duplicate_items(*collections) == expected

--- a/inferno/utils.py
+++ b/inferno/utils.py
@@ -85,7 +85,8 @@ def check_history_slice(history, sl):
         return
     except KeyError as exc:
         msg = ("Key '{}' could not be found in history; "
-               "maybe there was a typo?".format(exc.args[0]))
+               "maybe there was a typo? To make this key optional, "
+               "add it to the 'keys_optional' parameter.".format(exc.args[0]))
         raise KeyError(msg)
 
 

--- a/inferno/utils.py
+++ b/inferno/utils.py
@@ -108,7 +108,32 @@ def is_pandas_ndframe(x):
 
 def flatten(arr):
     for item in arr:
-        if isinstance(item, (tuple, list)):
+        if isinstance(item, (tuple, list, dict)):
             yield from flatten(item)
         else:
             yield item
+
+
+def duplicate_items(*collections):
+    """Search for duplicate items in all collections.
+
+    Examples
+    --------
+    >>> duplicate_items([1, 2], [3])
+    set()
+    >>> duplicate_items({1: 'a', 2: 'a'})
+    set()
+    >>> duplicate_items(['a', 'b', 'a'])
+    {'a'}
+    >>> duplicate_items([1, 2], {3: 'hi', 4: 'ha'}, (2, 3))
+    {2, 3}
+
+    """
+    duplicates = set()
+    seen = set()
+    for item in flatten(collections):
+        if item in seen:
+            duplicates.add(item)
+        else:
+            seen.add(item)
+    return duplicates


### PR DESCRIPTION
Main changes:
* Callbacks now have an `keys_optional` keyword that allows to exclude keys from check.
* An additional check for duplicate keys has been added.
* Error messages have been improved.

*Note*: The idea of telling the user exactly how to `set_params` to a add a key to `keys_optional` does not work. For that, we would need to know the name of the callback, since the name is part of the `set_params` path. However, we don't know the callback name at the time of the call.