### PR TITLE
`y=None` causes trouble in many cases

### DIFF
--- a/inferno/__init__.py
+++ b/inferno/__init__.py
@@ -1,3 +1,3 @@
-from .net import History, NeuralNet, NeuralNetClassifier
+from .net import History, NeuralNet, NeuralNetClassifier, NeuralNetRegressor
 
 from . import callbacks

--- a/inferno/dataset.py
+++ b/inferno/dataset.py
@@ -1,6 +1,5 @@
 from functools import partial
 
-import numpy as np
 from sklearn.utils import safe_indexing
 import torch
 import torch.utils.data

--- a/inferno/dataset.py
+++ b/inferno/dataset.py
@@ -94,26 +94,6 @@ def multi_indexing(data, i):
     return safe_indexing(data, i)
 
 
-def is_zero_dimensional(x):
-    """0-dimensional data structures are defined as not having a length."""
-    return not hasattr(x, '__len__')
-
-
-def is_one_dimensional(data):
-    """Checks whether the input data is a one-dimensional data structure."""
-    if isinstance(data, dict):
-        # dictionary of containers
-        return all([is_zero_dimensional(v) for v in data.values()])
-    if isinstance(data, (list, tuple)):
-        return all([is_zero_dimensional(v) for v in data])
-    if torch.is_tensor(data):
-        # torch tensor-like
-        return len(data.size()) == 1
-    if is_pandas_ndframe(data) or isinstance(data, np.ndarray):
-        return len(data.shape) == 1
-    return True
-
-
 class Dataset(torch.utils.data.Dataset):
     """General dataset wrapper that can be used in conjunction with
     pytorch's DataLoader.

--- a/inferno/dataset.py
+++ b/inferno/dataset.py
@@ -160,7 +160,11 @@ class Dataset(torch.utils.data.Dataset):
 
         xi = multi_indexing(X, i)
         if y is None:
-            # pytorch DataLoader cannot deal with None
+            # pytorch DataLoader cannot deal with None so we use 0 as
+            # a placeholder value. We only return a scalar value here
+            # (as opposed to `batchsz` values) since the pytorch DataLoader
+            # calls __getitem__ for each row in the batch anyway, which
+            # results in a dummy `y` value for each row in the batch.
             yi = 0
         else:
             yi = multi_indexing(y, i)

--- a/inferno/net.py
+++ b/inferno/net.py
@@ -792,9 +792,6 @@ class NeuralNetClassifier(NeuralNet):
                              "(and your validation) and supply it using the "
                              "`iterator_train` and `iterator_valid` "
                              "parameters respectively.")
-        elif y is None:
-            # The user implements its own mechanism for generating y.
-            return
 
     def get_loss(self, y_pred, y, train=False):
         y_pred_log = torch.log(y_pred)

--- a/inferno/net.py
+++ b/inferno/net.py
@@ -785,6 +785,17 @@ class NeuralNetClassifier(NeuralNet):
             **kwargs
         )
 
+    def check_data(self, _, y):
+        if y is None and self.iterator_train is DataLoader:
+            raise ValueError("No y-values are given (y=None). You must "
+                             "implement your own DataLoader for training "
+                             "(and your validation) and supply it using the "
+                             "`iterator_train` and `iterator_valid` "
+                             "parameters respectively.")
+        elif y is None:
+            # The user implements its own mechanism for generating y.
+            return
+
     def get_loss(self, y_pred, y, train=False):
         y_pred_log = torch.log(y_pred)
         return self.criterion_(y_pred_log, y)
@@ -818,6 +829,16 @@ class NeuralNetRegressor(NeuralNet):
         )
 
     def check_data(self, _, y):
+        if y is None and self.iterator_train is DataLoader:
+            raise ValueError("No y-values are given (y=None). You must "
+                             "implement your own DataLoader for training "
+                             "(and your validation) and supply it using the "
+                             "`iterator_train` and `iterator_valid` "
+                             "parameters respectively.")
+        elif y is None:
+            # The user implements its own mechanism for generating y.
+            return
+
         # The problem with 1-dim float y is that the pytorch DataLoader will
         # somehow upcast it to DoubleTensor
         if get_dim(y) == 1:

--- a/inferno/tests/test_dataset.py
+++ b/inferno/tests/test_dataset.py
@@ -73,24 +73,30 @@ class TestNetWithoutY:
                 return F.softmax(self.dense(X.float()))
         return MyModule
 
-    @pytest.fixture
-    def net_1d(self, net_cls_1d):
+    @pytest.fixture(params=[
+        {'batch_size': 1},
+        {'batch_size': 2},
+    ])
+    def net_1d(self, request, net_cls_1d):
         from inferno import NeuralNetClassifier
         return NeuralNetClassifier(
             net_cls_1d,
             max_epochs=2,
             lr=0.1,
-            batch_size=1,
+            batch_size=request.param['batch_size'],
         )
 
-    @pytest.fixture
-    def net_2d(self, net_cls_2d):
+    @pytest.fixture(params=[
+        {'batch_size': 1},
+        {'batch_size': 2},
+    ])
+    def net_2d(self, request, net_cls_2d):
         from inferno import NeuralNetClassifier
         return NeuralNetClassifier(
             net_cls_2d,
             max_epochs=2,
             lr=0.1,
-            batch_size=1,
+            batch_size=request.param['batch_size']
         )
 
     def test_net_1d_tensor(self, net_1d):

--- a/inferno/tests/test_dataset.py
+++ b/inferno/tests/test_dataset.py
@@ -93,26 +93,6 @@ class TestNetWithoutY:
             batch_size=1,
         )
 
-    @pytest.fixture
-    def is_one_dimensional(self):
-        from inferno.dataset import is_one_dimensional
-        return is_one_dimensional
-
-    @pytest.mark.parametrize('data, expected', [
-        (np.zeros((5)), True),
-        (np.zeros((5,5)), False),
-        ([1], True),
-        ([1,2], True),
-        ([[1],[2]], False),
-        ({1: 2, 2: 3}, True),
-        ({1: [2], 2: [3]}, False),
-        ({1: 2, 2: [3]}, False),
-        (torch.zeros(2), True),
-        (torch.zeros((2,2)), False),
-    ])
-    def test_one_dimensional(self, is_one_dimensional, data, expected):
-        assert is_one_dimensional(data) == expected
-
     def test_net_1d_tensor(self, net_1d):
         # Should not raise an exception
         X = torch.Tensor([1,2,3,4,5,6,7])

--- a/inferno/tests/test_dataset.py
+++ b/inferno/tests/test_dataset.py
@@ -60,43 +60,23 @@ class TestNetWithoutY:
     ]
 
     @pytest.fixture
-    def net_cls_1d_clf(self):
+    def net_cls_1d(self):
         class MyModule(nn.Module):
             def __init__(self):
                 super(MyModule, self).__init__()
                 self.dense = nn.Linear(1,1)
             def forward(self, X):
-                return F.softmax(self.dense(X.float()))
+                return self.dense(X.float())
         return MyModule
 
     @pytest.fixture
-    def net_cls_2d_clf(self):
+    def net_cls_2d(self):
         class MyModule(nn.Module):
             def __init__(self):
                 super(MyModule, self).__init__()
                 self.dense = nn.Linear(2,1)
             def forward(self, X):
-                return F.softmax(self.dense(X.float()))
-        return MyModule
-
-    @pytest.fixture
-    def net_cls_1d_reg(self):
-        class MyModule(nn.Module):
-            def __init__(self):
-                super(MyModule, self).__init__()
-                self.dense = nn.Linear(1,1)
-            def forward(self, X):
-                return F.tanh(self.dense(X.float()))
-        return MyModule
-
-    @pytest.fixture
-    def net_cls_2d_reg(self):
-        class MyModule(nn.Module):
-            def __init__(self):
-                super(MyModule, self).__init__()
-                self.dense = nn.Linear(2,1)
-            def forward(self, X):
-                return F.tanh(self.dense(X.float()))
+                return self.dense(X.float())
         return MyModule
 
     @pytest.fixture
@@ -116,55 +96,49 @@ class TestNetWithoutY:
         return Loader
 
     @pytest.fixture(params=net_fixture_params)
-    def net_1d(self, request, net_cls_1d_clf, net_cls_1d_reg):
+    def net_1d(self, request, net_cls_1d):
         if request.param['classification']:
             from inferno import NeuralNetClassifier
             wrap_cls = NeuralNetClassifier
-            net_cls = net_cls_1d_clf
         else:
             from inferno import NeuralNetRegressor
             wrap_cls = NeuralNetRegressor
-            net_cls = net_cls_1d_reg
 
         return wrap_cls(
-            net_cls,
+            net_cls_1d,
             max_epochs=2,
             batch_size=request.param['batch_size']
         )
 
     @pytest.fixture(params=net_fixture_params)
-    def net_2d(self, request, net_cls_2d_clf, net_cls_2d_reg):
+    def net_2d(self, request, net_cls_2d):
         if request.param['classification']:
             from inferno import NeuralNetClassifier
             wrap_cls = NeuralNetClassifier
-            net_cls = net_cls_2d_clf
         else:
             from inferno import NeuralNetRegressor
             wrap_cls = NeuralNetRegressor
-            net_cls = net_cls_2d_clf
 
         return wrap_cls(
-            net_cls,
+            net_cls_2d,
             max_epochs=2,
             batch_size=request.param['batch_size']
         )
 
     @pytest.fixture(params=net_fixture_params)
-    def net_1d_custom_loader(self, request, net_cls_1d_clf, net_cls_1d_reg,
+    def net_1d_custom_loader(self, request, net_cls_1d,
                              loader_clf, loader_reg):
         if request.param['classification']:
             from inferno import NeuralNetClassifier
             wrap_cls = NeuralNetClassifier
             loader = loader_clf
-            net_cls = net_cls_1d_clf
         else:
             from inferno import NeuralNetRegressor
             wrap_cls = NeuralNetRegressor
             loader = loader_reg
-            net_cls = net_cls_1d_reg
 
         return wrap_cls(
-            net_cls,
+            net_cls_1d,
             iterator_train=loader,
             iterator_test=loader,
             max_epochs=2,
@@ -172,21 +146,19 @@ class TestNetWithoutY:
         )
 
     @pytest.fixture(params=net_fixture_params)
-    def net_2d_custom_loader(self, request, net_cls_2d_clf, net_cls_2d_reg,
+    def net_2d_custom_loader(self, request, net_cls_2d,
                              loader_clf, loader_reg):
         if request.param['classification']:
             from inferno import NeuralNetClassifier
             wrap_cls = NeuralNetClassifier
             loader = loader_clf
-            net_cls = net_cls_2d_clf
         else:
             from inferno import NeuralNetRegressor
             wrap_cls = NeuralNetRegressor
             loader = loader_reg
-            net_cls = net_cls_2d_reg
 
         return wrap_cls(
-            net_cls,
+            net_cls_2d,
             iterator_train=loader,
             iterator_test=loader,
             max_epochs=2,

--- a/inferno/tests/test_dataset.py
+++ b/inferno/tests/test_dataset.py
@@ -49,6 +49,82 @@ class TestGetLen:
             get_len(data)
 
 
+class TestNetWithoutY:
+
+    @pytest.fixture
+    def net_cls_1d(self):
+        class MyModule(nn.Module):
+            def __init__(self):
+                super(MyModule, self).__init__()
+                self.dense = nn.Linear(1,1)
+
+            def forward(self, X):
+                return F.softmax(self.dense(X.unsqueeze(1).float()))
+        return MyModule
+
+    @pytest.fixture
+    def net_cls_2d(self):
+        class MyModule(nn.Module):
+            def __init__(self):
+                super(MyModule, self).__init__()
+                self.dense = nn.Linear(2,1)
+
+            def forward(self, X):
+                return F.softmax(self.dense(X.float()))
+        return MyModule
+
+    @pytest.fixture
+    def net_1d(self, net_cls_1d):
+        from inferno import NeuralNetClassifier
+        return NeuralNetClassifier(
+            net_cls_1d,
+            max_epochs=2,
+            lr=0.1,
+            batch_size=1,
+        )
+
+    @pytest.fixture
+    def net_2d(self, net_cls_2d):
+        from inferno import NeuralNetClassifier
+        return NeuralNetClassifier(
+            net_cls_2d,
+            max_epochs=2,
+            lr=0.1,
+            batch_size=1,
+        )
+
+    @pytest.fixture
+    def is_one_dimensional(self):
+        from inferno.dataset import is_one_dimensional
+        return is_one_dimensional
+
+    @pytest.mark.parametrize('data, expected', [
+        (np.zeros((5)), True),
+        (np.zeros((5,5)), False),
+        ([1], True),
+        ([1,2], True),
+        ([[1],[2]], False),
+        ({1: 2, 2: 3}, True),
+        ({1: [2], 2: [3]}, False),
+        ({1: 2, 2: [3]}, False),
+        (torch.zeros(2), True),
+        (torch.zeros((2,2)), False),
+    ])
+    def test_one_dimensional(self, is_one_dimensional, data, expected):
+        assert is_one_dimensional(data) == expected
+
+    def test_net_1d_tensor(self, net_1d):
+        # Should not raise an exception
+        X = torch.Tensor([1,2,3,4,5,6,7])
+        net_1d.fit(X, None)
+
+    def test_net_2d_tensor(self, net_2d):
+        X = torch.Tensor([[1,2],[3,4],[5,6]])
+        net_2d.fit(X, None)
+
+    # TODO: test regression with dummy y as well
+
+
 class TestMultiIndexing:
     @pytest.fixture
     def multi_indexing(self):

--- a/inferno/tests/test_dataset.py
+++ b/inferno/tests/test_dataset.py
@@ -74,11 +74,18 @@ class TestNetWithoutY:
         return MyModule
 
     @pytest.fixture(params=[
-        {'batch_size': 1},
-        {'batch_size': 2},
+        {'classifier': True, 'batch_size': 1},
+        {'classifier': True, 'batch_size': 2},
+        {'classifier': False, 'batch_size': 1},
+        {'classifier': False, 'batch_size': 2},
     ])
     def net_1d(self, request, net_cls_1d):
-        from inferno import NeuralNetClassifier
+        if request.param['classifier']:
+            from inferno import NeuralNetClassifier
+            cls = NeuralNetClassifier
+        else:
+            from inferno import NeuralNetRegressor
+            cls = NeuralNetRegressor
         return NeuralNetClassifier(
             net_cls_1d,
             max_epochs=2,
@@ -87,12 +94,19 @@ class TestNetWithoutY:
         )
 
     @pytest.fixture(params=[
-        {'batch_size': 1},
-        {'batch_size': 2},
+        {'classifier': True, 'batch_size': 1},
+        {'classifier': True, 'batch_size': 2},
+        {'classifier': False, 'batch_size': 1},
+        {'classifier': False, 'batch_size': 2},
     ])
     def net_2d(self, request, net_cls_2d):
-        from inferno import NeuralNetClassifier
-        return NeuralNetClassifier(
+        if request.param['classifier']:
+            from inferno import NeuralNetClassifier
+            cls = NeuralNetClassifier
+        else:
+            from inferno import NeuralNetRegressor
+            cls = NeuralNetRegressor
+        return cls(
             net_cls_2d,
             max_epochs=2,
             lr=0.1,


### PR DESCRIPTION
in classifier `fit(X, y=None)` causes problems:
-  for inputs with shape `(n,m)` as it will create `y` with shape `(n,1)` whereas shape `(n,)` would be needed
- for inputs with shape `(n,)` as it will try to access the length of each element to create appropriate dummy values (but the child is a number, not a sequence)

I added tests and a fix for these cases, although regression is still missing.
