### PR TITLE
Bugfix: pandas test not skipped

### DIFF
--- a/inferno/tests/test_dataset.py
+++ b/inferno/tests/test_dataset.py
@@ -336,9 +336,10 @@ class TestMultiIndexing:
         assert np.allclose(result[2].long().numpy(), np.arange(3, 5))
         assert result[3] == {'a': [4, 5], 'b': [7, 8]}
 
-    @pytest.mark.skipif(not pandas_installed, reason='pandas is not installed')
     @pytest.fixture
     def pd(self):
+        if not pandas_installed:
+            pytest.skip()
         import pandas as pd
         return pd
 

--- a/inferno/tests/test_dataset.py
+++ b/inferno/tests/test_dataset.py
@@ -1,6 +1,4 @@
 from unittest.mock import Mock
-from unittest.mock import patch
-
 import numpy as np
 import pytest
 from sklearn.datasets import make_classification


### PR DESCRIPTION
The reason was that `pytest.mark.skipif` is simply ignored when used in conjuction with a `pytest.fixture`.