### PR TITLE
Feature: initialized modules

### DIFF
--- a/inferno/net.py
+++ b/inferno/net.py
@@ -416,11 +416,13 @@ class NeuralNet(Callback):
             callbacks_.append((name, cb))
 
         self.callbacks_ = callbacks_
+        return self
 
     def initialize_criterion(self):
         """Initializes the criterion."""
         criterion_params = self._get_params_for('criterion')
         self.criterion_ = self.criterion(**criterion_params)
+        return self
 
     def initialize_module(self):
         """Initializes the module.
@@ -429,13 +431,23 @@ class NeuralNet(Callback):
         reset.
 
         """
-        if self.initialized_:
-            print("Re-initializing module!")
-
         kwargs = self._get_params_for('module')
-        self.module_ = self.module(**kwargs)
+        module = self.module
+        is_initialized = not isinstance(module, type)
+
+        if kwargs or not is_initialized:
+            if is_initialized:
+                module = type(module)
+
+            if is_initialized or self.initialized_:
+                print("Re-initializing module!")
+
+            module = module(**kwargs)
+
         if self.use_cuda:
-            self.module_.cuda()
+            module.cuda()
+
+        self.module_ = module
         return self
 
     def initialize(self):

--- a/inferno/tests/test_net.py
+++ b/inferno/tests/test_net.py
@@ -438,7 +438,7 @@ class TestNeuralNet:
         assert weight.shape[0] == 123
 
         stdout = capsys.readouterr()[0]
-        assert stdout.startswith("Re-initializing module!")
+        assert "Re-initializing module!" in stdout
 
     def test_with_initialized_module_non_default(
             self, net_cls, module_cls, data, capsys):
@@ -449,7 +449,7 @@ class TestNeuralNet:
         assert weight.shape[0] == 123
 
         stdout = capsys.readouterr()[0]
-        assert not stdout.startswith("Re-initializing module!")
+        assert "Re-initializing module!" not in stdout
 
     def test_with_initialized_module_partial_fit(
             self, net_cls, module_cls, data, capsys):
@@ -463,7 +463,7 @@ class TestNeuralNet:
             assert (p0 == p1).data.all()
 
         stdout = capsys.readouterr()[0]
-        assert not stdout.startswith("Re-initializing module!")
+        assert "Re-initializing module!" not in stdout
 
     def test_with_initialized_module_warm_start(
             self, net_cls, module_cls, data, capsys):
@@ -477,7 +477,7 @@ class TestNeuralNet:
             assert (p0 == p1).data.all()
 
         stdout = capsys.readouterr()[0]
-        assert not stdout.startswith("Re-initializing module!")
+        assert "Re-initializing module!" not in stdout
 
     def test_with_initialized_sequential(
             self, net_cls, module_cls, data, capsys):
@@ -492,7 +492,7 @@ class TestNeuralNet:
         net.fit(X, y)
 
         stdout = capsys.readouterr()[0]
-        assert not stdout.startswith("Re-initializing module!")
+        assert "Re-initializing module!" not in stdout
 
     def test_call_fit_twice_retrains(self, net_cls, module_cls, data):
         # test that after second fit call, even without entering the

--- a/inferno/tests/test_net.py
+++ b/inferno/tests/test_net.py
@@ -484,7 +484,7 @@ class TestNeuralNet:
         X, y = data
         module = nn.Sequential(
             nn.Linear(X.shape[1], 10),
-            nn.ReLu(),
+            nn.ReLU(),
             nn.Linear(10, 2),
             nn.Softmax(),
         )


### PR DESCRIPTION
It is now possible to pass an initialized torch module to NeuralNet (e.g. an nn.Sequential). Iff a param is set on that module, it is re-initialized.

Addresses #39