### PR TITLE
Initialize Dataset only once per fit call

### DIFF
--- a/inferno/dataset.py
+++ b/inferno/dataset.py
@@ -174,6 +174,10 @@ class Dataset(torch.utils.data.Dataset):
         By default, they are cast to torch tensors. Override this if
         you want a different behavior.
 
+        Note: If you use this in conjuction with pytorch's DataLoader,
+        the latter will call the dataset for each row separately,
+        which means that the incoming X and y each are single rows.
+
         """
         # pytorch DataLoader cannot deal with None so we use 0 as a
         # placeholder value. We only return a Tensor with one value


### PR DESCRIPTION
`get_iterator` is now called with `dataset` instead of X and y.

The advantage is that we don't redundantly initialize the stateless `Dataset`. If there is a costly transformation on X and y, it is now possible to perform it in the `transform` method of `Dataset` once before the fit loop, instead of performing it once at the start of each epoch.

I also expanded some of the docstrings.