### PR TITLE
Allow CVSplit to take an optional random_state argument

### DIFF
--- a/inferno/dataset.py
+++ b/inferno/dataset.py
@@ -235,9 +235,21 @@ class CVSplit(object):
       Whether the split should be stratified. Only works if `y` is
       either binary or multiclass classification.
 
-    """
-    def __init__(self, cv=5, stratified=False):
+    random_state : int, RandomState instance, or None (default=None)
+      Control the random state in case that `(Stratified)ShuffleSplit`
+      is used (which is when a float is passed to `cv`). For more
+      information, look at the sklearn documentation of
+      `(Stratified)ShuffleSplit`.
+
+      """
+    def __init__(
+            self,
+            cv=5,
+            stratified=False,
+            random_state=None,
+    ):
         self.stratified = stratified
+        self.random_state = random_state
 
         if isinstance(cv, Number) and (cv <= 0):
             raise ValueError("Numbers less than 0 are not allowed for cv "
@@ -254,7 +266,7 @@ class CVSplit(object):
 
     def _check_cv_float(self, y):
         cv_cls = StratifiedShuffleSplit if self.stratified else ShuffleSplit
-        return cv_cls(test_size=self.cv)
+        return cv_cls(test_size=self.cv, random_state=self.random_state)
 
     def _check_cv_non_float(self, y):
         return check_cv(

--- a/inferno/net.py
+++ b/inferno/net.py
@@ -248,7 +248,7 @@ class NeuralNet(Callback):
       accept a `use_cuda` parameter to indicate whether cuda should be
       used.
 
-    train_split : None, function or callable (default=inferno.dataset.CVSplit(0.2))
+    train_split : None, function or callable (default=inferno.dataset.CVSplit(5))
       If None, there is no train/validation split. Else, train_split
       should be a function or callable that is called with X and y
       data and should return the tuple `X_train, X_valid, y_train,
@@ -324,7 +324,7 @@ class NeuralNet(Callback):
             iterator_train=DataLoader,
             iterator_test=DataLoader,
             dataset=Dataset,
-            train_split=CVSplit(0.2),
+            train_split=CVSplit(5),
             callbacks=None,
             cold_start=True,
             use_cuda=False,
@@ -893,7 +893,7 @@ class NeuralNetClassifier(NeuralNet):
             self,
             module,
             criterion=torch.nn.NLLLoss,
-            train_split=CVSplit(0.2, stratified=True),
+            train_split=CVSplit(5, stratified=True),
             *args,
             **kwargs
     ):

--- a/inferno/tests/test_dataset.py
+++ b/inferno/tests/test_dataset.py
@@ -1,4 +1,6 @@
 from unittest.mock import Mock
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 from sklearn.datasets import make_classification
@@ -941,3 +943,23 @@ class TestCVSplit:
 
         expected = "Stratified CV not possible with given y."
         assert exc.value.args[0] == expected
+
+    def test_shuffle_split_reproducible_with_random_state(self, cv_split_cls):
+        X, y = np.random.random((100, 10)), np.random.randint(0, 10, size=100)
+        cv = cv_split_cls(0.2, stratified=False)
+        Xt0, Xv0, yt0, yv0 = cv(X, y)
+        Xt1, Xv1, yt1, yv1 = cv(X, y)
+
+        assert not np.allclose(Xt0, Xt1)
+        assert not np.allclose(Xv0, Xv1)
+        assert not np.allclose(yt0, yt1)
+        assert not np.allclose(yv0, yv1)
+
+        cv = cv_split_cls(0.2, stratified=False, random_state=0)
+        Xt0, Xv0, yt0, yv0 = cv(X, y)
+        Xt1, Xv1, yt1, yv1 = cv(X, y)
+
+        assert np.allclose(Xt0, Xt1)
+        assert np.allclose(Xv0, Xv1)
+        assert np.allclose(yt0, yt1)
+        assert np.allclose(yv0, yv1)


### PR DESCRIPTION
It is passed to `(Stratified)ShuffleSplit` if that is used. Before this change, if a float is used with `CVSplit`, the split would be non-deterministic.

For the other cases, `random_state` is simply ignored, since `check_cv` does not take it as argument.