### PR TITLE
pandas is not required in the setup.py and hence removed.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ with open('VERSION', 'r') as f:
 
 install_requires = [
     'numpy',
-    'pandas',
     'scikit-learn>=0.18',
     'scipy',
 ]


### PR DESCRIPTION
It should not have been in there, as usage with `pandas` is optional.

@ottonemo Please review.