### PR TITLE
Fix bug that occurs with classification and cuda.

### DIFF
--- a/inferno/net.py
+++ b/inferno/net.py
@@ -924,10 +924,11 @@ class NeuralNetClassifier(NeuralNet):
                              "parameters respectively.")
 
     def _prepare_target_for_loss(self, y):
-        # This is an ugly work-around (relating to #56), but
+        # This is a temporary, ugly work-around (relating to #56), but
         # currently, I see no solution that would result in a 1-dim
         # LongTensor after passing through torch's DataLoader. If
-        # there is, we should use that instead.
+        # there is, we should use that instead. Otherwise, this will
+        # be obsolete once pytorch scalars arrive.
         if (y.dim() == 2) and (y.size(1) == 1):
             # classification: y must be 1d
             return y[:, 0]

--- a/inferno/tests/test_net.py
+++ b/inferno/tests/test_net.py
@@ -427,6 +427,7 @@ class TestNeuralNet:
         with pytest.raises(KeyError):
             net.history[:, 'valid_loss']
 
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="no cuda device")
     def test_use_cuda_on_model(self, net_cls, module_cls):
         net_cuda = net_cls(module_cls, use_cuda=True)
         net_cuda.initialize()
@@ -570,6 +571,14 @@ class TestNeuralNet:
         assert len(net.history) == 10
         for p0, p1 in zip(params_before, params_after):
             assert (p0 == p1).data.all()
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="no cuda device")
+    def test_binary_classification_with_cuda(self, net_cls, module_cls, data):
+        X, y = data
+        assert y.ndim == 1
+
+        net = net_cls(module_cls, max_epochs=1, use_cuda=True)
+        net.fit(X, y)
 
 
 class MyRegressor(nn.Module):

--- a/inferno/utils.py
+++ b/inferno/utils.py
@@ -59,6 +59,8 @@ def to_tensor(X, use_cuda=False):
 
     if isinstance(X, collections.abc.Sequence):
         X = torch.from_numpy(np.array(X))
+    elif np.isscalar(X):
+        X = torch.from_numpy(np.array([X]))
 
     if use_cuda:
         X = X.cuda()


### PR DESCRIPTION
The problem was that `.cuda()` is called on a numpy scalar. To fix this, we have to wrap the scalar into a numpy array, but then `default_collate` will turn this into a n x 1 Tensor, which fails with `NLLLoss`. Consequently, `NeuralNetClassifier` intercepts n x 1 Tensors and flattens them.

@ottonemo pls review