### PR TITLE
Attempt at fixing #70

### DIFF
--- a/inferno/exceptions.py
+++ b/inferno/exceptions.py
@@ -1,4 +1,4 @@
-"""Contains inferno-specific exceptions."""
+"""Contains inferno-specific exceptions and warnings."""
 
 
 class InfernoException(BaseException):

--- a/inferno/exceptions.py
+++ b/inferno/exceptions.py
@@ -10,3 +10,11 @@ class NotInitializedError(InfernoException):
     method or train the model by calling `.fit(...)`.
 
     """
+
+
+class InfernoWarning(UserWarning):
+    """Base inferno warning."""
+
+
+class DeviceWarning(InfernoWarning):
+    """A problem with a device (e.g. CUDA) was detected."""

--- a/inferno/tests/test_net.py
+++ b/inferno/tests/test_net.py
@@ -153,6 +153,7 @@ class TestNeuralNet:
         score_after = accuracy_score(y, net_new.predict(X))
         assert np.isclose(score_after, score_before)
 
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="no cuda device")
     def test_pickle_save_load_cuda_intercompatibility(
             self, net_cls, module_cls, tmpdir):
         from inferno.exceptions import DeviceWarning
@@ -248,6 +249,7 @@ class TestNeuralNet:
                     "or by fitting the model with `.fit(...)`.")
         assert exc.value.args[0] == expected
 
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="no cuda device")
     def test_save_load_state_cuda_intercompatibility(
             self, net_cls, module_cls, tmpdir):
         net = net_cls(module_cls, use_cuda=True).initialize()

--- a/inferno/tests/test_net.py
+++ b/inferno/tests/test_net.py
@@ -155,6 +155,8 @@ class TestNeuralNet:
 
     def test_pickle_save_load_cuda_intercompatibility(
             self, net_cls, module_cls, tmpdir):
+        from inferno.exceptions import DeviceWarning
+
         net = net_cls(module=module_cls, use_cuda=True).initialize()
 
         p = tmpdir.mkdir('inferno').join('testmodel.pkl')
@@ -163,10 +165,11 @@ class TestNeuralNet:
         del net
 
         with patch('torch.cuda.is_available', lambda *_: False):
-            with pytest.warns(ResourceWarning) as w:
+            with pytest.warns(DeviceWarning) as w:
                 with open(str(p), 'rb') as f:
                     pickle.load(f)
 
+        assert len(w.list) == 1  # only 1 warning
         assert w.list[0].message.args[0] == (
             'Model configured to use CUDA but no CUDA '
             'devices available. Loading on CPU instead.')


### PR DESCRIPTION
Use `torch.load` so we can use the location mapping feature
which enables us to remap GPU storage to CPU storage.